### PR TITLE
Fixed audio

### DIFF
--- a/app.py
+++ b/app.py
@@ -93,7 +93,7 @@ def audio_helper():
             full_text += f"{subheading_data['subheading']}. {subheading_data['explanation']} "
 
         # Convert the full text to audio
-        converter = TextToSpeechConverter(full_text, output_dir='audio_output', language='en')
+        converter = TextToSpeechConverter(full_text, output_dir='static', language='en')
         audio_file_path = converter.convert_to_audio(filename='output_audio.mp3')
 
         return audio_file_path
@@ -152,7 +152,7 @@ def play_audio():
     if summarize_dict_output is not None:
         audio_file_path = audio_helper()
         if audio_file_path:
-            audio_url = url_for('static', filename=os.path.basename(audio_file_path), _external=True)
+            audio_url = url_for('static', filename='output_audio.mp3', _external=True)
             return jsonify({"success": True, "audio_url": audio_url})
         else:
             return jsonify({"error": "Failed to convert to audio"})


### PR DESCRIPTION
Turns out audio is dependent based on the user's browsers auto play policy. So if it's restricted, you will run into this error: "NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission". However, with this fix the code works. Probably need to look into other ways but I think browser restriction is something we cannot control?